### PR TITLE
Browser warning and tweaks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,11 +4,25 @@ import './fonts/InputMono-Regular.ttf';
 import './fonts/InputMono-Medium.ttf';
 
 import {Synth} from './components/Synth';
+import {useScreenSize} from './hooks/use-screen-size';
 
 export default function App() {
+  const {width} = useScreenSize();
+
+  const bannerContent = width < 960 && (
+    <div className="browser-warning">
+      HelloSynth works best on a desktop computer in Google Chrome.
+    </div>
+  );
+
   return (
     <div className="App">
+      {bannerContent}
       <Synth />
+      <div className="footer">
+        HelloSynth is free and open source on{' '}
+        <a href="https://github.com/cicadasound/hello-synthesizer">GitHub</a>
+      </div>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ export default function App() {
 
   const bannerContent = width < 960 && (
     <div className="browser-warning">
-      HelloSynth works best on a desktop computer in Google Chrome.
+      HelloSynth works best on a desktop computer in Google Chrome, for now.
     </div>
   );
 

--- a/src/components/LFO.js
+++ b/src/components/LFO.js
@@ -52,11 +52,11 @@ export function LFO({title, lfo, onChange}) {
         <label>Amount</label>
         <RangeSlider
           min={0}
-          max={1000}
+          max={999}
           step={1}
           minpos={0}
-          maxpos={100}
-          scale="log"
+          maxpos={999}
+          scale="exponential"
           value={lfo.level}
           onChange={(value) => handleChange('level', value)}
         />

--- a/src/components/Oscillator.js
+++ b/src/components/Oscillator.js
@@ -83,6 +83,7 @@ export function Oscillator({title, osc, onChange}) {
           min="-1200"
           max="1200"
           step="10"
+          scale="exponential"
           value={osc.detune}
           highlightCentre
           onChange={(value) => handleChange('detune', value)}

--- a/src/hooks/use-screen-size.js
+++ b/src/hooks/use-screen-size.js
@@ -1,0 +1,24 @@
+import {useState, useEffect} from 'react';
+
+function getScreenSize() {
+  const {innerWidth: width, innerHeight: height} = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export function useScreenSize() {
+  const [screenSize, setScreenSize] = useState(getScreenSize());
+
+  useEffect(() => {
+    function handleResize() {
+      setScreenSize(getScreenSize());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return screenSize;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1189,3 +1189,33 @@ input[type='range']::-ms-track {
 .icon--rotate-270 {
   transform: rotate(270deg);
 }
+
+/* Browser warning */
+.browser-warning {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  font-family: var(--font-family-mono);
+  margin-top: 1rem;
+  padding: 2rem;
+  border-radius: 0.6rem;
+  border: var(--border-width) solid var(--green);
+  background: transparent;
+  color: var(--green);
+  width: 100%;
+}
+
+/* Footer */
+
+.footer {
+  font-size: 0.8rem;
+  font-weight: 200;
+  color: white;
+}
+
+.footer a {
+  font-size: 0.8rem;
+  font-weight: 200;
+  color: white;
+}


### PR DESCRIPTION
This adds a new banner if the users screen size is less than 940, since we don't really have responsive styles for it.

<img width="499" alt="Screenshot 2023-04-22 at 9 11 23 AM" src="https://user-images.githubusercontent.com/478990/233787171-294fd4c0-d50d-4311-8a97-2793ec1b1c5a.png">

It also adds a little footer that links to the GitHub repo

<img width="1082" alt="Screenshot 2023-04-22 at 9 11 38 AM" src="https://user-images.githubusercontent.com/478990/233787170-772837db-b38e-4bb9-8db6-8326da460099.png">

And then lastly it tweaks the values for the LFO amount and OSC tuning to be a bit more useful.
